### PR TITLE
Pass session object to fs_tag_as_rfigshare()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -27,6 +27,12 @@ And constructed with the following guidelines:
 
 For more information on SemVer, please visit http://semver.org/.
 
+v0.3.7.100
+----------
+
+- `fs_tag_as_rfigshare()` accepts and passes `session` object to support
+  unattended uploads [#105](https://github.com/ropensci/rfigshare/pull/105).
+
 v0.3.7
 ------
 

--- a/R/fs_tag_as_rfigshare.R
+++ b/R/fs_tag_as_rfigshare.R
@@ -1,10 +1,10 @@
 
-fs_tag_as_rfigshare <- function(article_id) {
+fs_tag_as_rfigshare <- function(article_id, session = fs_get_auth()) {
 # Check if tagged yet
-  o <- fs_details(article_id, mine=TRUE)
+  o <- fs_details(article_id, mine=TRUE, session=session)
   tag <- "Published using rfigshare"
   m <- match(tag, sapply(o$tags, `[[`, "name"))
   out <- if(is.na(m))
-    fs_add_tags(article_id, tag)
+    fs_add_tags(article_id, tag, session=session)
   invisible(out)
 }

--- a/R/fs_upload.R
+++ b/R/fs_upload.R
@@ -58,6 +58,6 @@ fs_upload_one  <- function(article_id, file, session = fs_get_auth()) {
   body <- list(filedata = upload_file(file))
   config <- c(config(token = session), add_headers("Content-Type" = "multipart/form-data"))
   out <- PUT(request, config = config, body = body)
-  fs_tag_as_rfigshare(article_id)
+  fs_tag_as_rfigshare(article_id, session = session)
   out
 }


### PR DESCRIPTION
for unattended deployment.