### PR TITLE
improve category docs

### DIFF
--- a/R/fs_add_categories.R
+++ b/R/fs_add_categories.R
@@ -6,7 +6,7 @@
 #' @param session (optional) the authentication credentials from \code{\link{fs_auth}}. If not provided, will attempt to load from cache as long as figshare_auth has been run.  
 #' @param debug return PUT results visibly?
 #' @return output of PUT request (invisibly)
-#' @seealso \code{\link{fs_auth}}
+#' @seealso \code{\link{fs_auth}} \code{\link{fs_category_list}}
 #' @references \url{http://api.figshare.com}
 #' @import RJSONIO httr
 #' @export

--- a/R/fs_category_list.R
+++ b/R/fs_category_list.R
@@ -7,7 +7,7 @@
 #' @param debug enable debugging
 #' @export
 #' @examples \dontrun{
-#' fs_categories_list()
+#' as.data.frame(rbind(fs_category_list()))
 #' }
 fs_category_list <- function(debug = FALSE){
     response <- GET("http://api.figshare.com/v1/categories")

--- a/man/fs_add_categories.Rd
+++ b/man/fs_add_categories.Rd
@@ -4,8 +4,12 @@
 \alias{fs_add_categories}
 \title{Add a category to article}
 \usage{
-fs_add_categories(article_id, category_id, session = fs_get_auth(),
-  debug = FALSE)
+fs_add_categories(
+  article_id,
+  category_id,
+  session = fs_get_auth(),
+  debug = FALSE
+)
 }
 \arguments{
 \item{article_id}{the id number of the article}
@@ -31,7 +35,7 @@ fs_add_categories(138, "Ecology")
 \url{http://api.figshare.com}
 }
 \seealso{
-\code{\link{fs_auth}}
+\code{\link{fs_auth}} \code{\link{fs_category_list}}
 }
 \author{
 Edmund Hart \email{edmund.m.hart@gmail.com}

--- a/man/fs_category_list.Rd
+++ b/man/fs_category_list.Rd
@@ -17,7 +17,7 @@ List all categories
 }
 \examples{
 \dontrun{
-fs_categories_list()
+as.data.frame(rbind(fs_category_list()))
 }
 }
 \references{


### PR DESCRIPTION
I went down a rabbit hole of figshare category codes until I discovered `fs_category_list`. This PR creates a cross reference from `fs_add_categories`, fixes a typo in the `fs_category_list` example code, and shows how to return the results as a sortable `data.frame`.